### PR TITLE
Arey: Corrección error línea 7 de la RSI del ping.

### DIFF
--- a/12/RSI_Ping.s
+++ b/12/RSI_Ping.s
@@ -4,7 +4,7 @@ RSI_Ping:
 	ldr r2, =fase
 	ldrb r0, [r2]
 	cmp r0, #0
-	beq .Lcapturar_tiempo
+	bne .Lcapturar_tiempo
 	bl cpuStartTiming
 	mov r0, #1
 	b .Lfin_capturar_tiempo


### PR DESCRIPTION
Se ha cambiado la instrucción 'beq .Lcapturar_tiempo' por la instrucción 'bne .Lcapturar_tiempo'. Aunque la primera instrucción es correcta desde un punto de vista de sintaxis de ARM, es incorrecta en la resolución del problema dado que llevaría a que la instrucción 'bl cpuGetTiming' se ejecutase antes que la instrucción 'bl cpuStartTiming' cosa que sin duda provocaría errores de ejecución.